### PR TITLE
Fix complex int16 dn dtype slc

### DIFF
--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -81,7 +81,6 @@ class Sentinel1Dataset:
         }
         if dtypes is not None:
             self._dtypes.update(dtypes)
-
         # default meta for map_blocks output.
         # as asarray is imported from numpy, it's a numpy array.
         # but if later we decide to import asarray from cupy, il will be a cupy.array (gpu)


### PR DESCRIPTION
small fix to allow `rasterio` `complex_int16` to be interpreted as `np.complex_` in order to fix the dtype casting error in case of coarse resolution options on SLC (complex Digital Number).
For instance 
xsar.open_dataset(wv_slc_meta.subdatasets[good_indice],resolution=resolutionZ,resampling=rasterio.enums.Resampling.rms)
is now possible.
Note that rasterio will be probably replaced by rioxarray in xarray backends: https://github.com/pydata/xarray/issues/5491 