### PR TITLE
add missing annotation parameters needed for SLC TOPS reading

### DIFF
--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -376,6 +376,9 @@ class Sentinel1Meta:
     def bursts(self):
         return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
 
+    @property
+    def orbit(self):
+        return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'orbit')
 
 
     @property

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import pdb
-
 import cartopy.feature
 import logging
 import warnings

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -297,30 +297,6 @@ class Sentinel1Meta:
             self._orbit_pass = self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.pass')
         return self._orbit_pass
 
-    @property
-    def number_of_bursts(self):
-        """
-        for instance 9 bursts for a subswath IW
-        """
-
-        if self.multidataset:
-            return None  # not defined for multidataset
-        if self._number_of_bursts is None:
-            self._number_of_bursts = self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.number_of_bursts')
-        logger.debug('number of bursts %s %s',self._number_of_bursts,type(self._number_of_bursts))
-        return self._number_of_bursts
-
-    @property
-    def lines_per_burst(self):
-        """
-        """
-
-        if self.multidataset:
-            return None  # not defined for multidataset
-        if self._lines_per_burst is None:
-            self._lines_per_burst = self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.lines_per_burst')
-        return self._lines_per_burst
-
 
     @property
     def nb_geoDcPoly(self):
@@ -396,6 +372,9 @@ class Sentinel1Meta:
             }
         return self._geoloc
 
+    @property
+    def bursts(self):
+        return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
 
 
 
@@ -468,17 +447,6 @@ class Sentinel1Meta:
         if self._nb_dcestimate is None:
             self._nb_dcestimate = self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.nb_dcestimate')
         return self._nb_dcestimate
-
-    @property
-    def samples_per_burst(self):
-        """
-        """
-
-        if self.multidataset:
-            return None  # not defined for multidataset
-        if self._samples_per_burst is None:
-            self._samples_per_burst = self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.samples_per_burst')
-        return self._samples_per_burst
 
 
     @property

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from collections import OrderedDict
 from .ipython_backends import repr_mimebundle
 
+
 logger = logging.getLogger('xsar.sentinel1_meta')
 logger.addHandler(logging.NullHandler())
 
@@ -380,6 +381,9 @@ class Sentinel1Meta:
     def orbit(self):
         return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'orbit')
 
+    @property
+    def azimuth_fmrate(self):
+        return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'azimuth_fmrate')
 
     @property
     def number_of_lines(self):

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -12,6 +12,11 @@ import warnings
 import geopandas as gpd
 from shapely.geometry import Polygon
 import os.path
+import logging
+import netCDF4
+
+logger = logging.getLogger('xsar.sentinel1_xml_mappings')
+logger.addHandler(logging.NullHandler())
 
 namespaces = {
     "xfdu": "urn:ccsds:schema:xfdu:1",
@@ -21,17 +26,21 @@ namespaces = {
     "safe": "http://www.esa.int/safe/sentinel-1.0",
     "gml": "http://www.opengis.net/gml"
 }
-
+TIMEUNITS = 'seconds since 1990-01-01T00:00:00' # copy pasted from cerbere
 # xpath convertion function: they take only one args (list returned by xpath)
 scalar = lambda x: x[0]
+scalar_int = lambda x: int(x[0])
 scalar_float = lambda x: float(x[0])
 date_converter = lambda x: datetime.strptime(x[0], '%Y-%m-%dT%H:%M:%S.%f')
 datetime64_array = lambda x: np.array([np.datetime64(date_converter([sx])) for sx in x])
+datetum_array = lambda x: np.array([netCDF4.date2num(date_converter([sx]),units=TIMEUNITS) for sx in x])
 int_1Darray_from_string = lambda x: np.fromstring(x[0], dtype=int, sep=' ')
 float_2Darray_from_string_list = lambda x: np.vstack([np.fromstring(e, dtype=float, sep=' ') for e in x])
 int_1Darray_from_join_strings = lambda x: np.fromstring(" ".join(x), dtype=int, sep=' ')
 float_1Darray_from_join_strings = lambda x: np.fromstring(" ".join(x), dtype=float, sep=' ')
 int_array = lambda x: np.array(x, dtype=int)
+bool_array = lambda x: np.array(x, dtype=bool)
+float_array = lambda x: np.array(x,dtype=float)
 uniq_sorted = lambda x: np.array(sorted(set(x)))
 ordered_category = lambda x: pd.Categorical(x).reorder_categories(x, ordered=True)
 normpath = lambda paths: [os.path.normpath(p) for p in paths]
@@ -126,8 +135,8 @@ xpath_mappings = {
         'elevation': (
             np.array, '/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/elevationAngle'),
         'height':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/height'),
-        'azimuth_time':(datetime64_array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/azimuthTime'),
-        'slant_range_time':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/slantRangeTime'),
+        'azimuth_time':(datetum_array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/azimuthTime'),
+        'slant_range_time_lr':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/slantRangeTime'),
         'longitude_lr':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/longitude'),
         'latitude_lr':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/latitude'),
         'polarization': (scalar, '/product/adsHeader/polarisation'),
@@ -137,11 +146,58 @@ xpath_mappings = {
         'pol': (scalar, '/product/adsHeader/polarisation'),
         'pass': (scalar, '/product/generalAnnotation/productInformation/pass'),
         'platform_heading': (scalar_float, '/product/generalAnnotation/productInformation/platformHeading'),
-        'number_of_bursts':(scalar,'/product/swathTiming/burstList/@count'),
+        'number_of_bursts':(scalar_int,'/product/swathTiming/burstList/@count'),
+        'number_of_lines':(scalar,'/product/imageAnnotation/imageInformation/numberOfLines'),
+        'incidence_angle_mid_swath':(scalar,'/product/imageAnnotation/imageInformation/incidenceAngleMidSwath'),
+        'number_of_samples':(scalar,'/product/imageAnnotation/imageInformation/numberOfSamples'),
         'lines_per_burst':(scalar,'/product/swathTiming/linesPerBurst'),
         'samples_per_burst':(scalar,'/product/swathTiming/samplesPerBurst'),
         'azimuth_time_interval':(scalar_float,'/product/imageAnnotation/imageInformation/azimuthTimeInterval'),
         'npoints_geolocgrid':(scalar,'/product/geolocationGrid/geolocationGridPointList/@count'),
+        'all_bursts':(np.array,'//product/swathTiming/burstList/burst'),
+        'burst_azimuthTime':(np.array,'//product/swathTiming/burstList/burst/azimuthTime'),
+        'burst_azimuthAnxTime':(np.array,'//product/swathTiming/burstList/burst/azimuthAnxTime'),
+        'burst_sensingTime':(np.array,'//product/swathTiming/burstList/burst/sensingTime'),
+        'burst_byteOffset':(np.array,'//product/swathTiming/burstList/burst/byteOffset'),
+        'burst_firstValidSample':(float_2Darray_from_string_list,'//product/swathTiming/burstList/burst/firstValidSample'),
+        'burst_lastValidSample':(float_2Darray_from_string_list,'//product/swathTiming/burstList/burst/lastValidSample'),
+        'radar_frequency':(scalar_float,'/product/generalAnnotation/productInformation/radarFrequency'),
+        'nb_state_vector':(scalar_int,'/product/generalAnnotation/orbitList/@count'),
+        'nb_fmrate':(scalar_int,'/product/generalAnnotation/azimuthFmRateList/@count'),
+        'fmrate_azimuthtime':(np.array,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/azimuthTime'),
+        'fmrate_t0':(float_array,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/t0'),
+        'fmrate_c0':(np.array,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/c0'),
+        'fmrate_c1':(np.array,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/c1'),
+        'fmrate_c2':(np.array,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/c2'),
+        'fmrate_azimuthFmRatePolynomial':(float_2Darray_from_string_list,'//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/azimuthFmRatePolynomial'),
+        'orbit_time':(np.array,'//product/generalAnnotation/orbitList/orbit/time'),
+        'orbit_frame':(np.array,'//product/generalAnnotation/orbitList/orbit/frame'),
+        'orbit_pos_x':(np.array,'//product/generalAnnotation/orbitList/orbit/position/x'),
+        'orbit_pos_y':(np.array,'//product/generalAnnotation/orbitList/orbit/position/y'),
+        'orbit_pos_z':(np.array,'//product/generalAnnotation/orbitList/orbit/position/z'),
+        'orbit_vel_x':(np.array,'//product/generalAnnotation/orbitList/orbit/velocity/x'),
+        'orbit_vel_y':(np.array,'//product/generalAnnotation/orbitList/orbit/velocity/y'),
+        'orbit_vel_z':(np.array,'//product/generalAnnotation/orbitList/orbit/velocity/z'),
+        'azimuth_steering_rate':(scalar_float,'/product/generalAnnotation/productInformation/azimuthSteeringRate'),
+        'nb_dcestimate':(scalar_int,'/product/dopplerCentroid/dcEstimateList/@count'),
+        'nb_geoDcPoly':(scalar_int,'/product/dopplerCentroid/dcEstimateList/dcEstimate[1]/geometryDcPolynomial/@count'),
+        'nb_dataDcPoly':(scalar_int,'/product/dopplerCentroid/dcEstimateList/dcEstimate[1]/dataDcPolynomial/@count'),
+        'nb_fineDce':(scalar_int,'/product/dopplerCentroid/dcEstimateList/dcEstimate[1]/fineDceList/@count'),
+        'dc_azimuth_time':(np.array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/azimuthTime'),
+        'dc_t0':(np.array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/t0'),
+        'dc_geoDcPoly':(float_2Darray_from_string_list,'//product/dopplerCentroid/dcEstimateList/dcEstimate/geometryDcPolynomial'),
+        'dc_dataDcPoly':(float_2Darray_from_string_list,'//product/dopplerCentroid/dcEstimateList/dcEstimate/dataDcPolynomial'),
+        'dc_rmserr':(np.array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/dataDcRmsError'),
+        'dc_rmserrAboveThres':(bool_array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/dataDcRmsErrorAboveThreshold'),
+        'dc_azstarttime':(np.array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/fineDceAzimuthStartTime'),
+        'dc_azstoptime':(np.array,'//product/dopplerCentroid/dcEstimateList/dcEstimate/fineDceAzimuthStopTime'),
+        'dc_slantRangeTime':(np.array,'///product/dopplerCentroid/dcEstimateList/dcEstimate/fineDceList/fineDce/slantRangeTime'),
+        'dc_frequency':(np.array,'///product/dopplerCentroid/dcEstimateList/dcEstimate/fineDceList/fineDce/frequency'),
+        'range_sampling_rate':(scalar_float,'/product/generalAnnotation/productInformation/rangeSamplingRate'),
+        'slant_range_time':(scalar_float,'/product/imageAnnotation/imageInformation/slantRangeTime'),
+        'rangePixelSpacing':(scalar_float,'/product/imageAnnotation/imageInformation/rangePixelSpacing'),
+        'azimuthPixelSpacing':(scalar_float,'/product/imageAnnotation/imageInformation/azimuthPixelSpacing'),
+
     }
 }
 
@@ -149,6 +205,7 @@ xpath_mappings = {
 # compounds variables converters
 
 def signal_lut(atrack, xtrack, lut):
+    logger.debug('signal lut on atrack %s xtrack %s lut : %s',atrack.shape,xtrack.shape,lut.shape)
     lut_f = RectBivariateSpline(atrack, xtrack, lut, kx=1, ky=1)
     return lut_f
 
@@ -406,4 +463,12 @@ compounds_vars = {
         'func': annotation_angle,
         'args': ('annotation.atrack', 'annotation.xtrack', 'annotation.height')
     },
+    'slant_range_time': {
+        'func': annotation_angle,
+        'args': ('annotation.atrack', 'annotation.xtrack', 'annotation.slant_range_time_lr')
+    },
+    # 'azimuth_time': {
+    #     'func': signal_lut,
+    #     'args':('annotation.atrack','annotation.xtrack','annotation.azimuth_time')
+    # }
 }

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -119,17 +119,29 @@ xpath_mappings = {
     'annotation': {
         'atrack': (uniq_sorted, '/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/line'),
         'xtrack': (uniq_sorted, '/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/pixel'),
+        'line':(int_array,'//product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/line'), #same as atrack but return a 10x21 matrix
+        'pixel':(int_array,'//product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/pixel'), #same as atrack but return a 10x21 matrix
         'incidence': (
             np.array, '/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/incidenceAngle'),
         'elevation': (
             np.array, '/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/elevationAngle'),
+        'height':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/height'),
+        'azimuth_time':(datetime64_array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/azimuthTime'),
+        'slant_range_time':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/slantRangeTime'),
+        'longitude_lr':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/longitude'),
+        'latitude_lr':(np.array,'/product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/latitude'),
         'polarization': (scalar, '/product/adsHeader/polarisation'),
         'atrack_time_range': (
             datetime64_array, '/product/imageAnnotation/imageInformation/*[contains(name(),"LineUtcTime")]'),
         'denoised': (scalar, '/product/imageAnnotation/processingInformation/thermalNoiseCorrectionPerformed'),
         'pol': (scalar, '/product/adsHeader/polarisation'),
         'pass': (scalar, '/product/generalAnnotation/productInformation/pass'),
-        'platform_heading': (scalar_float, '/product/generalAnnotation/productInformation/platformHeading')
+        'platform_heading': (scalar_float, '/product/generalAnnotation/productInformation/platformHeading'),
+        'number_of_bursts':(scalar,'/product/swathTiming/burstList/@count'),
+        'lines_per_burst':(scalar,'/product/swathTiming/linesPerBurst'),
+        'samples_per_burst':(scalar,'/product/swathTiming/samplesPerBurst'),
+        'azimuth_time_interval':(scalar_float,'/product/imageAnnotation/imageInformation/azimuthTimeInterval'),
+        'npoints_geolocgrid':(scalar,'/product/geolocationGrid/geolocationGridPointList/@count'),
     }
 }
 

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -402,4 +402,8 @@ compounds_vars = {
         'func': annotation_angle,
         'args': ('annotation.atrack', 'annotation.xtrack', 'annotation.elevation')
     },
+    'height': {
+        'func': annotation_angle,
+        'args': ('annotation.atrack', 'annotation.xtrack', 'annotation.height')
+    },
 }

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -172,7 +172,7 @@ xpath_mappings = {
         'fmrate_azimuthFmRatePolynomial': (
             float_2Darray_from_string_list,
             '//product/generalAnnotation/azimuthFmRateList/azimuthFmRate/azimuthFmRatePolynomial'),
-        'orbit_time': (np.array, '//product/generalAnnotation/orbitList/orbit/time'),
+        'orbit_time': (datetime64_array, '//product/generalAnnotation/orbitList/orbit/time'),
         'orbit_frame': (np.array, '//product/generalAnnotation/orbitList/orbit/frame'),
         'orbit_pos_x': (np.array, '//product/generalAnnotation/orbitList/orbit/position/x'),
         'orbit_pos_y': (np.array, '//product/generalAnnotation/orbitList/orbit/position/y'),
@@ -459,6 +459,19 @@ def bursts(lines_per_burst, samples_per_burst, burst_azimuthTime, burst_azimuthA
         }
     )
 
+def orbit(orbit_time, orbit_frame, orbit_pos_x, orbit_pos_y, orbit_pos_z, orbit_vel_x, orbit_vel_y, orbit_vel_z):
+
+    return pd.DataFrame(
+        {
+            'frame': orbit_frame,
+            'pos_x': orbit_pos_x,
+            'pos_y': orbit_pos_y,
+            'pos_z': orbit_pos_z,
+            'vel_x': orbit_vel_x,
+            'vel_y': orbit_vel_y,
+            'vel_z': orbit_vel_z
+        }, index=orbit_time
+    )
 
 # dict of compounds variables.
 # compounds variables are variables composed of several variables.
@@ -538,5 +551,11 @@ compounds_vars = {
         'args': ('annotation.lines_per_burst', 'annotation. samples_per_burst', 'annotation. burst_azimuthTime',
                  'annotation. burst_azimuthAnxTime', 'annotation. burst_sensingTime', 'annotation.burst_byteOffset',
                  'annotation. burst_firstValidSample', 'annotation.burst_lastValidSample')
+    },
+    'orbit': {
+        'func': orbit,
+        'args': ('annotation.orbit_time', 'annotation.orbit_frame',
+                 'annotation.orbit_pos_x', 'annotation.orbit_pos_y', 'annotation.orbit_pos_z',
+                 'annotation.orbit_vel_x', 'annotation.orbit_vel_y', 'annotation.orbit_vel_z')
     }
 }


### PR DESCRIPTION
This PR is meant to prepare the SLC TOPS decoding including the overlapping bursts along azimuth axis in each subswath.
- [x] add _number_of_bursts
- [x] add _lines_per_burst
- [x] add _samples_per_burst
- [x] add _azimuth_time_interval
- [x]  add _npoints_geolocgrid 
- [x]  add height from geolocation grid
- [x] add slant_range_time from geolocation grid
- [x] add ground_spacing() method in the Sentinel1Dataset()
- [x] add informations about swathtiming
- [x] validation of the geolocation grid annotations versus cerbere
- [x] validation of the swathtiming annotations versus cerbere
- [x] valdiation of the doppler centroid estimates annotations versus cerbere
- [x] validation of orbit state vector annotations versus cerbere
- [x] validation of the azimuth fm rate annotations versus cerbere
- [x] validation of the azimuth_time variable versus cerbere
- [ ] test EW SLC product
- [ ] test IW SLC previous IPF versions
- [ ] validate full cross spectrum computation algorithm versus sar_tops_inversion ODL 
- [x]  check that the annotation files is always the right one in `sentinel1_meta.py`
- [ ] fix variables that depend on azimuth_time to skip the overlapping burst lines (8)