### PR TITLE
Fix bug libgdal.30.so in ubuntu and macOS test workflow

### DIFF
--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -23,7 +23,7 @@ jobs:
           activate-environment: xsar
       - name: Create Env
         run: |
-          conda install -c conda-forge rasterio'>=1.2.6' gdal'>=3.3'  dask[array] dask[distributed] 'shapely<1.8.0'
+          conda install -c conda-forge rasterio'>=1.2.6' gdal'>=3.3'  dask[array] dask[distributed] rioxarray 'shapely<1.8.0'
           conda install -c conda-forge  jupyterlab geoviews cartopy_offlinedata holoviews datashader nbsphinx pandoc jq docutils 'shapely<1.8.0'
       - name: Install xsar
         run: |

--- a/.github/workflows/generate-doc.yml
+++ b/.github/workflows/generate-doc.yml
@@ -1,11 +1,12 @@
 name: Generate Xsar Documentation
 
 on:
-#  release:
-#    types: [ published ]
-  push:
-      branches:
-        - develop
+  release:
+    types: [ published ]
+# for testing uncomment trigger in push
+#  push:
+#      branches:
+#        - develop
 
 jobs:
   build:

--- a/.github/workflows/mac-os-install-test.yml
+++ b/.github/workflows/mac-os-install-test.yml
@@ -30,7 +30,7 @@ jobs:
           activate-environment: xsar
           python-version: ${{ matrix.python-version }}
       - name: Install xsar dependencies
-        run: conda install -c conda-forge rasterio">=1.2.6" gdal cartopy_offlinedata dask[array] tbb rioxarray pytest
+        run: conda install -c conda-forge rasterio">=1.2.6,<1.2.10" gdal">=3.3" gdal cartopy_offlinedata dask[array] tbb rioxarray pytest
       - name: Install xsar
         run: |
           pip install -e .

--- a/.github/workflows/ubuntu-install-test.yml
+++ b/.github/workflows/ubuntu-install-test.yml
@@ -30,7 +30,7 @@ jobs:
           activate-environment: xsar
           python-version: ${{ matrix.python-version }}
       - name: Install xsar dependencies
-        run: conda install -c conda-forge rasterio">=1.2.6" gdal cartopy_offlinedata rioxarray dask[array] pytest
+        run: conda install -c conda-forge rasterio">=1.2.6,<1.2.10" gdal">=3.3" cartopy_offlinedata rioxarray dask[array] pytest
       - name: Install xsar
         run: |
           pip install -e .


### PR DESCRIPTION
Solution is to fix Rasterio <1.2.10 the consequence is the  gdal version is 3.3