### PR TITLE
Add 'history' attributes to variables with xpath from xml files

### DIFF
--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -1,0 +1,26 @@
+import xarray as xr
+import datetime
+import numpy as np
+
+def ecmwf_01_1h_reader(fname):
+    """ecmwf 0.1 deg 1h reader (ECMWF_FORECAST_0100_202109091300_10U_10V.nc)"""
+    ecmwf_ds = xr.open_dataset(fname).isel(time=0)
+    ecmwf_ds.attrs['time'] = datetime.datetime.fromtimestamp(ecmwf_ds.time.item() // 1000000000)
+    ecmwf_ds = ecmwf_ds.drop_vars('time').rename(
+        {
+            'Longitude': 'longitude',
+            'Latitude': 'latitude',
+            '10U': 'U10',
+            '10V': 'V10'
+        }
+    )
+    ecmwf_ds['WSPD'] = np.sqrt(ecmwf_ds.U10**2 + ecmwf_ds.V10**2)
+    ecmwf_ds.attrs = {k: ecmwf_ds.attrs[k] for k in ['title', 'institution', 'time']}
+
+    # dataset is lon [0, 360], make it [-180,180]
+    ecmwf_ds = ecmwf_ds.roll(longitude=-ecmwf_ds.longitude.size // 2, roll_coords=True)
+    ecmwf_ds['longitude'] = xr.where(ecmwf_ds['longitude'] >= 180, ecmwf_ds['longitude'] - 360, ecmwf_ds['longitude'])
+
+    ecmwf_ds.rio.write_crs("EPSG:4326", inplace=True)
+
+    return ecmwf_ds

--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -49,7 +49,7 @@ def resource_strftime(resource, **kwargs):
 
 def ecmwf_0100_1h(fname):
     """ecmwf 0.1 deg 1h reader (ECMWF_FORECAST_0100_202109091300_10U_10V.nc)"""
-    ecmwf_ds = xr.open_dataset(fname).isel(time=0)
+    ecmwf_ds = xr.open_dataset(fname, chunks={'Longitude': 1000, 'Latitude': 1000}).isel(time=0)
     ecmwf_ds.attrs['time'] = datetime.datetime.fromtimestamp(ecmwf_ds.time.item() // 1000000000)
     ecmwf_ds = ecmwf_ds.drop_vars('time').rename(
         {
@@ -79,19 +79,6 @@ def gebco(gebco_files):
             ).rename(x='longitude', y='latitude').isel(band=0).drop_vars('band') for f in gebco_files
         ]
     )
-
-
-# defaults read_function
-raster_readers = {
-    'ecmwf_0100_1h': ecmwf_0100_1h,
-    'gebco': gebco
-}
-
-# defaults get_function
-raster_getters = {
-    'ecmwf_0100_1h': bind(resource_strftime, ..., step=1),
-    'gebco': glob.glob
-}
 
 # list available rasters as a pandas dataframe
 available_rasters = pd.DataFrame(columns=['resource', 'read_function', 'get_function'])

--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -1,8 +1,52 @@
 import xarray as xr
 import datetime
 import numpy as np
+import glob
+from .utils import bind
 
-def ecmwf_01_1h_reader(fname):
+
+def resource_strftime(resource, **kwargs):
+    """
+    From a resource string like '%Y/%j/myfile_%Y%m%d%H%M.nc' and a date like 'Timestamp('2018-10-13 06:23:22.317102')',
+    returns a string like '/2018/286/myfile_201810130600.nc'
+
+    Parameters
+    ----------
+    resource: str
+
+        resource string, with strftime template
+
+    date: datetime
+
+        date to be used
+
+    step: int
+
+        hour step between 2 files
+
+
+    Returns
+    -------
+    str
+
+    """
+
+    date = kwargs['date']
+    step = kwargs['step']
+
+    delta = datetime.timedelta(hours=step) / 2
+    date = date.replace(
+        year=(date+delta).year,
+        month=(date+delta).month,
+        day=(date+delta).day,
+        hour=(date+delta).hour // step * step,
+        minute=0,
+        second=0,
+        microsecond=0
+    )
+    return date.strftime(resource)
+
+def ecmwf_0100_1h(fname):
     """ecmwf 0.1 deg 1h reader (ECMWF_FORECAST_0100_202109091300_10U_10V.nc)"""
     ecmwf_ds = xr.open_dataset(fname).isel(time=0)
     ecmwf_ds.attrs['time'] = datetime.datetime.fromtimestamp(ecmwf_ds.time.item() // 1000000000)
@@ -24,3 +68,26 @@ def ecmwf_01_1h_reader(fname):
     ecmwf_ds.rio.write_crs("EPSG:4326", inplace=True)
 
     return ecmwf_ds
+
+def gebco(gebco_files):
+    """gebco file reader (geotiff from https://www.gebco.net/data_and_products/gridded_bathymetry_data)"""
+    return xr.combine_by_coords(
+        [
+            xr.open_dataset(
+                f, chunks={'x': 1000, 'y': 1000}
+            ).rename(x='longitude', y='latitude').isel(band=0).drop_vars('band') for f in gebco_files
+        ]
+    )
+
+
+# defaults read_function
+raster_readers = {
+    'ecmwf_0100_1h': ecmwf_0100_1h,
+    'gebco': gebco
+}
+
+# defaults get_function
+raster_getters = {
+    'ecmwf_0100_1h': bind(resource_strftime, ..., step=1),
+    'gebco': glob.glob
+}

--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -67,7 +67,6 @@ def ecmwf_0100_1h(fname):
             '10V': 'V10'
         }
     )
-    ecmwf_ds['WSPD'] = np.sqrt(ecmwf_ds.U10**2 + ecmwf_ds.V10**2)
     ecmwf_ds.attrs = {k: ecmwf_ds.attrs[k] for k in ['title', 'institution', 'time']}
 
     # dataset is lon [0, 360], make it [-180,180]

--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -3,6 +3,7 @@ import datetime
 import numpy as np
 import glob
 from .utils import bind
+import pandas as pd
 
 
 def resource_strftime(resource, **kwargs):
@@ -91,3 +92,8 @@ raster_getters = {
     'ecmwf_0100_1h': bind(resource_strftime, ..., step=1),
     'gebco': glob.glob
 }
+
+# list available rasters as a pandas dataframe
+available_rasters = pd.DataFrame(columns=['resource', 'read_function', 'get_function'])
+available_rasters.loc['gebco'] = [None, gebco, glob.glob]
+available_rasters.loc['ecmwf_0100_1h'] = [None, ecmwf_0100_1h, bind(resource_strftime, ..., step=1)]

--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -640,6 +640,7 @@ class Sentinel1Dataset:
         ]
         return xr.merge(da_list)
 
+    @timing
     def _load_rasters_vars(self):
         # load and map variables from rasterfile (like ecmwf) on dataset
         if self.s1meta.rasters.empty:
@@ -678,7 +679,8 @@ class Sentinel1Dataset:
                 logger.info('adding variable "%s"' % varname)
                 # FIXME: antimed
                 # FIXME: RectBivariateSpline
-                # FIXME: map_blocks
+                if raster_ds[var].chunks is None:
+                    raise ValueError('Using a chunked dataarray is mandatory')
                 raster_ds[var] = raster_ds[var].drop_vars(['spatial_ref', 'crs'], errors='ignore')
                 interpolated_val = raster_ds[var].interp(longitude=self._dataset.longitude, latitude=self._dataset.latitude)
                 interpolated_val = interpolated_val.drop_vars(['longitude', 'latitude', 'spatial_ref', 'crs'], errors='ignore')

--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -17,6 +17,7 @@ from numpy import asarray
 from affine import Affine
 from .sentinel1_meta import Sentinel1Meta
 from .ipython_backends import repr_mimebundle
+import json
 
 logger = logging.getLogger('xsar.sentinel1_dataset')
 logger.addHandler(logging.NullHandler())
@@ -647,17 +648,21 @@ class Sentinel1Dataset:
         if self.s1meta.rasters.empty:
             return None
         else:
-            logger.warning('raster variable is experimental')
+            logger.warning('Raster variable are experimental')
 
         if self.s1meta.cross_antemeridian:
             raise NotImplementedError('Antimeridian crossing not yet checked')
 
-        ds_lon = self._dataset.longitude.persist()
-        ds_lat = self._dataset.latitude.persist()
+        # get lon/lat box for xsar dataset
+        lons, lats = list(zip(*self.s1meta.footprint.exterior.coords))
+        lon_range = [min(lons), max(lons)]
+        lat_range = [min(lats), max(lats)]
 
-        ds_var_list = []
+        # will contain xr.DataArray to merge
+        da_var_list = []
 
         for name, infos in self.s1meta.rasters.iterrows():
+            # read the raster file using helpers functions
             read_function = infos['read_function']
             get_function = infos['get_function']
             resource = infos['resource']
@@ -668,36 +673,34 @@ class Sentinel1Dataset:
                 'footprint': self.s1meta.footprint
             }
 
+            logger.debug('adding raster "%s" from resource "%s"' % (name, str(resource)))
             if get_function is not None:
                 try:
                     resource = get_function(resource, **kwargs)
                 except TypeError:
                     resource = get_function(resource)
 
-            logger.info('adding raster "%s" from resource "%s"' % (name, str(resource)))
-            # TODO: delayed read
             if read_function is None:
-                raster_ds = xr.open_dataset(resource)
+                raster_ds = xr.open_dataset(resource, chunk=1000)
             else:
+                # read_function should return a chunked dataset (so it's fast)
                 raster_ds = read_function(resource)
 
+
+            # add globals raster attrs to globals dataset attrs
+            raster_ds.attrs['resource'] = resource
+            self._dataset.attrs[name] = json.dumps(raster_ds.attrs, indent=2, sort_keys=True, default=str)
+
             if not raster_ds.rio.crs.is_geographic:
-                # FIXME: antimed
                 raise NotImplementedError("Non geographic crs not implemented")
 
             # ensure dim ordering
             raster_ds = raster_ds.transpose('y', 'x')
-
             if np.all(raster_ds.y.diff('y') <= 0):
-                # sort y (lat) ascending
+                # sort y (lat) ascending (for RectBiVariateSpline)
                 raster_ds = raster_ds.reindex(y=raster_ds.y[::-1])
 
-
-
-            # select sub-data from raster_ds usinq s1 lon/lat
-            # extract sub raster from dataset lon/lat
-            lon_range = [ds_lon.min().compute().item(), ds_lon.max().compute().item()]
-            lat_range = [ds_lat.min().compute().item(), ds_lat.max().compute().item()]
+            # from lon/lat box in xsar dataset, get the corresponding box in raster_ds (by index)
             ilon_range = [
                 np.searchsorted(raster_ds.x.values, lon_range[0], side='right'),
                 np.searchsorted(raster_ds.x.values, lon_range[1], side='left')
@@ -706,62 +709,54 @@ class Sentinel1Dataset:
                 np.searchsorted(raster_ds.y.values, lat_range[0], side='right'),
                 np.searchsorted(raster_ds.y.values, lat_range[1], side='left')
             ]
+            # select the xsar box in the raster
             raster_ds = raster_ds.isel(x=slice(*ilon_range), y=slice(*ilat_range))
 
-            # 1D array of lons/lats, with approx same spacing as dataset
-            num = (ds_lon.xtrack.size +  ds_lon.atrack.size) // 2
+            # 1D array of lons/lats, trying to have same spacing as dataset (if not to high)
+            num = min((self._dataset.xtrack.size + self._dataset.atrack.size) // 2, 1000)
             lons = np.linspace(*lon_range, num=num)
             lats = np.linspace(*lat_range, num=num)
 
-            # resample raster_ds at approx xsar dataset resolution
+            @dask.delayed
+            def _map_raster2xsar(da):
+                # map the 'da' dataarray variable from the raster to xsar dataset
+                da = da.drop_vars(['spatial_ref', 'crs'], errors='ignore')
 
-            #raster_ds = raster_ds.interp(
-            #    x = np.linspace(*lon_range, num=ds_lon.xtrack.size),
-            #    y = np.linspace(*lat_range, num=ds_lon.xtrack.size),
-            #)
+                upscaled_da = map_blocks_coords(
+                    xr.DataArray(dims=['y', 'x'], coords={'x': lons, 'y': lats}).chunk(3000),
+                    RectBivariateSpline(da.y.values, da.x.values, da.values)
+                )
 
-
-
-            for var in raster_ds:
-                varname = '%s_%s' % (name, var)
-                logger.info('adding variable "%s"' % varname)
-
-                if raster_ds[var].chunks is None:
-                    raise ValueError('Using a chunked dataarray is mandatory')
-                raster_ds[var] = raster_ds[var].drop_vars(['spatial_ref', 'crs'], errors='ignore')
-
-
-                # We need to interpolate in 2 steps, to prevent hatching
-                # upscale raster resolution approx to xsar dataset,
-                # using RectBivariateSpline on same grid orientation
-                # FIXME: this took cputime at __init__: => delayed
-                interp_f = RectBivariateSpline(
-                    raster_ds[var].y.values,
-                    raster_ds[var].x.values,
-                    raster_ds[var].values)
-
-
-                upscaled_val = xr.DataArray(
-                    interp_f(
-                        *np.meshgrid(lats, lons),
-                        grid=False
-                    ),
-                    coords={'x': lons, 'y': lats}
-                ).chunk(1000).to_dataset(name=varname)
-
-                # reproject upscaled_val on xsar dataset.
-                # there will be no hatching, because upscaled_val if upscaled enough
-                # (.interp will just fill few missing points)
-                reprojected_val = upscaled_val.interp(
+                reprojected_da = upscaled_da.interp(
                     x=self._dataset.longitude,
                     y=self._dataset.latitude
                 )
+                reprojected_da = reprojected_da.drop_vars(['x', 'y', 'spatial_ref', 'crs'], errors='ignore')
+                reprojected_da.attrs.update(da.attrs)
 
-                reprojected_val = reprojected_val.drop_vars(['x', 'y', 'spatial_ref', 'crs'], errors='ignore')
-                reprojected_val[varname].attrs.update(raster_ds[var].attrs)
-                ds_var_list.append(reprojected_val)
+                reprojected_da.name = '%s_%s' % (name, da.name)
 
-        return xr.merge(ds_var_list)
+                # reprojected_da has same shape as other variables is xsar dataset, with optional 3rd dim
+                return reprojected_da
+
+
+            for var in raster_ds:
+                var_name = '%s_%s' % (name, raster_ds[var].name)
+                da_var = xr.DataArray(
+                    dask.array.from_delayed(
+                        _map_raster2xsar(raster_ds[var]),
+                        self._da_tmpl.shape,
+                        dtype='f8',
+                        name='%s' % var_name
+                    ),
+                    dims=['atrack', 'xtrack'],
+                    coords={'atrack': self._da_tmpl.atrack, 'xtrack': self._da_tmpl.xtrack},
+                    attrs=raster_ds[var].attrs
+                )
+                logger.debug('adding variable "%s" from raster "%s"' % (var_name, name))
+                da_var_list.append(da_var)
+
+        return xr.merge(da_var_list)
 
 
     def _get_lut(self, var_name):

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -586,7 +586,7 @@ class Sentinel1Meta:
     @property
     def cross_antemeridian(self):
         """True if footprint cross antemeridian"""
-        return (np.max(self.gcps['longitude']) - np.min(self.gcps['longitude'])) > 180
+        return ((np.max(self.gcps['longitude']) - np.min(self.gcps['longitude'])) > 180).item()
 
     @property
     def _dict_coords2ll(self):

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -42,6 +42,9 @@ class Sentinel1Meta:
         'land': cartopy.feature.NaturalEarthFeature('physical', 'land', '10m')
     }
 
+    rasters = available_rasters.iloc[0:0].copy()
+
+
     # class attributes are needed to fetch instance attribute (ie self.name) with dask actors
     # ref http://distributed.dask.org/en/stable/actors.html#access-attributes
     # FIXME: not needed if @property, so it might be a good thing to have getter for those attributes
@@ -123,7 +126,7 @@ class Sentinel1Meta:
         self._orbit_pass = None
         self._platform_heading = None
 
-        self.rasters = available_rasters.iloc[0:0].copy()
+        self.rasters = self.__class__.rasters.copy()
         """pandas dataframe for rasters (see `xsar.Sentinel1Meta.set_raster`)"""
 
     def __del__(self):
@@ -507,9 +510,6 @@ class Sentinel1Meta:
 
     @class_or_instancemethod
     def set_raster(self_or_cls, name, resource, read_function=None, get_function=None):
-        if isinstance(self_or_cls, type):
-            raise NotImplementedError("cls")
-
         # get defaults if exists
         default = available_rasters.loc[name:name]
 

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -118,8 +118,12 @@ class Sentinel1Meta:
         # get defaults masks from class attribute
         for name, feature in self.__class__._mask_features_raw.items():
             self.set_mask_feature(name, feature)
+
         self._orbit_pass = None
         self._platform_heading = None
+
+        self.rasters = pd.DataFrame(columns=['resource', 'read_function'])
+        """pandas dataframe for rasters (see `xsar.Sentinel1Meta.set_raster`)"""
 
     def __del__(self):
         logger.debug('__del__')
@@ -495,7 +499,19 @@ class Sentinel1Meta:
 
         return self._mask_features[name]
 
+    @class_or_instancemethod
+    def set_raster(self_or_cls, name, resource, read_function=None):
+        if isinstance(self_or_cls, type):
+            raise NotImplementedError("cls")
 
+        self_or_cls.rasters = pd.concat(
+            [
+                self_or_cls.rasters,
+                pd.DataFrame({'resource': resource, 'read_function': read_function}, index=[name])
+            ]
+        )
+
+        return
 
     @property
     def coverage(self):
@@ -826,6 +842,7 @@ class Sentinel1Meta:
             '_mask_features': {},
             '_mask_intersecting_geometries': {},
             '_mask_geometry': {},
+            'rasters': self.rasters
         }
         for name in minidict['_mask_features_raw'].keys():
             minidict['_mask_intersecting_geometries'][name] = None

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -440,7 +440,7 @@ class Sentinel1Meta:
         return self._mask_features.keys()
 
     @timing
-    def get_mask(self, name):
+    def get_mask(self, name, describe=False):
         """
         Get mask from `name` (e.g. 'land') as a shapely Polygon.
         The resulting polygon is contained in the footprint.
@@ -454,6 +454,17 @@ class Sentinel1Meta:
         shapely.geometry.Polygon
 
         """
+
+        if describe:
+            descr = self._mask_features_raw[name]
+            try:
+                # nice repr for a class (like 'cartopy.feature.NaturalEarthFeature land')
+                descr = '%s.%s %s' % (descr.__module__, descr.__class__.__name__ , descr.name)
+            except AttributeError:
+                pass
+            return descr
+
+
         if self._mask_geometry[name] is None:
             poly = self._get_mask_intersecting_geometries(name)\
                 .unary_union.intersection(self.footprint)

--- a/src/xsar/xml_parser.py
+++ b/src/xsar/xml_parser.py
@@ -2,9 +2,14 @@ from lxml import objectify
 import jmespath
 import logging
 from collections.abc import Iterable
+import os
+import re
+import json
+import yaml
 
 logger = logging.getLogger('xsar.xml_parser')
 logger.addHandler(logging.NullHandler())
+
 
 # TODO: no variable caching is not while  https://github.com/dask/distributed/issues/5610 is not solved
 class XmlParser:
@@ -50,10 +55,10 @@ class XmlParser:
         """
 
         xml_root = self.getroot(xml_file)
-        result = [ getattr(e, 'pyval', e) for e in xml_root.xpath(path, namespaces=self._namespaces) ]
+        result = [getattr(e, 'pyval', e) for e in xml_root.xpath(path, namespaces=self._namespaces)]
         return result
 
-    def get_var(self, xml_file, jpath):
+    def get_var(self, xml_file, jpath, describe=False):
         """
         get simple variable in xml_file.
 
@@ -63,6 +68,8 @@ class XmlParser:
             xml filename
         jpath: str
             jmespath string reaching xpath in xpath_mappings
+        describe: bool
+            If True, describe the variable (ie return xpath used)
 
         Returns
         -------
@@ -78,6 +85,9 @@ class XmlParser:
         if isinstance(xpath, tuple) and callable(xpath[0]):
             func, xpath = xpath
 
+        if describe:
+            return xpath
+
         if not isinstance(xpath, str):
             raise NotImplementedError('Non leaf xpath of type "%s" instead of str' % type(xpath).__name__)
 
@@ -87,15 +97,24 @@ class XmlParser:
 
         return result
 
-    def get_compound_var(self, xml_file, var_name):
+    def get_compound_var(self, xml_file, var_name, describe=False):
         """
 
         Parameters
         ----------
         var_name: str
+
             key in self._compounds_vars
+
         xml_file: str
+
             xml_file to use.
+
+        describe: bool
+
+            If True, only returns a string describing the variable (file, xpath, etc...)
+
+
 
         Returns
         -------
@@ -103,12 +122,18 @@ class XmlParser:
 
         """
 
+        if describe:
+            # keep only informative parts in filename
+            # sub SAFE path
+            minifile = re.sub('.*SAFE/', '', xml_file)
+            minifile = re.sub('-.*\.xml', '.xml', minifile)
+
         var_object = self._compounds_vars[var_name]
 
         func = None
-        if isinstance(var_object,dict) and 'func' in var_object and callable(var_object['func']):
+        if isinstance(var_object, dict) and 'func' in var_object and callable(var_object['func']):
             func = var_object['func']
-            if isinstance(var_object['args'],tuple):
+            if isinstance(var_object['args'], tuple):
                 args = var_object['args']
             else:
                 raise ValueError('args must be a tuple when func is called')
@@ -119,18 +144,24 @@ class XmlParser:
         if isinstance(args, dict):
             result = {}
             for key, path in args.items():
-                result[key] = self.get_var(xml_file, path)
+                result[key] = self.get_var(xml_file, path, describe=describe)
         elif isinstance(args, Iterable):
-            result = [self.get_var(xml_file, p) for p in args]
+            result = [self.get_var(xml_file, p, describe=describe) for p in args]
 
         if isinstance(args, tuple):
             result = tuple(result)
 
-        if func is not None:
+        if func is not None and not describe:
             # apply converter
             result = func(*result)
 
-        return result
+        if describe:
+            if isinstance(result, dict):
+                result = result.values()
+            description = yaml.safe_dump({var_name: {minifile: result}})
+            return description
+        else:
+            return result
 
     def __del__(self):
         logger.debug('__del__ XmlParser')

--- a/src/xsar/xsar.py
+++ b/src/xsar/xsar.py
@@ -11,9 +11,7 @@ __version__ = metadata.version('xsar')
 
 import logging
 from .utils import timing
-import numpy as np
 import os
-import numbers
 import yaml
 from importlib_resources import files
 from pathlib import Path
@@ -90,63 +88,8 @@ def open_dataset(*args, **kwargs):
     else:
         raise TypeError("Unknown dataset type from %s" % str(dataset_id))
 
-    return apply_cf_convention(sar_obj.dataset)
+    return sar_obj.dataset
 
-
-@timing
-def apply_cf_convention(dataset):
-    """
-    Apply `CF-1.7 convention <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html>`_ to a dataset
-
-    Parameters
-    ----------
-    dataset
-
-    Returns
-    -------
-    dataset wtih the cf convention
-    """
-
-    def to_cf(attr):
-        if not isinstance(attr, (str, numbers.Number, np.ndarray, np.number, list, tuple)):
-            return str(attr)
-        else:
-            return attr
-
-    attr_dict = {
-        'atrack': {
-            'units': '1'
-        },
-        'xtrack': {
-            'units': '1'
-        },
-        'longitude': {
-            'standard_name': 'longitude',
-            'units': 'degrees_east'
-        },
-        'latitude': {
-            'standard_name': 'latitude',
-            'units': 'degrees_north'
-        },
-        'sigma0_raw': {
-            'units': 'm2/m2'
-        },
-        'gamma0_raw': {
-            'units': 'm2/m2'
-        },
-    }
-
-    for k, v in dataset.attrs.items():
-        dataset.attrs[k] = to_cf(dataset.attrs[k])
-
-    dataset.attrs['Conventions'] = 'CF-1.7'
-
-    for key, attribute in attr_dict.items():
-        for key_attr, value in attribute.items():
-            if key in dataset:
-                dataset[key].attrs[key_attr] = value
-
-    return dataset
 
 def product_info(path, columns='minimal', include_multi=False, _xml_parser=None):
     """


### PR DESCRIPTION
As requested by @lanougue, this PR adds an 'history' attribute to almost all variables, in a yaml style string:

for example, for the 'incidence' variable:

```
incidence:
  annotation/s1b.xml:
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/line
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/pixel
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/incidenceAngle
```

