### PR TITLE
Add 'history' attributes to variables with xpath from xml files

### DIFF
--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -440,7 +440,7 @@ class Sentinel1Meta:
         return self._mask_features.keys()
 
     @timing
-    def get_mask(self, name):
+    def get_mask(self, name, describe=False):
         """
         Get mask from `name` (e.g. 'land') as a shapely Polygon.
         The resulting polygon is contained in the footprint.
@@ -454,6 +454,17 @@ class Sentinel1Meta:
         shapely.geometry.Polygon
 
         """
+
+        if describe:
+            descr = self._mask_features_raw[name]
+            try:
+                # nice repr for a class (like 'cartopy.feature.NaturalEarthFeature land')
+                descr = '%s.%s %s' % (descr.__module__, descr.__class__.__name__ , descr.name)
+            except AttributeError:
+                pass
+            return descr
+
+
         if self._mask_geometry[name] is None:
             poly = self._get_mask_intersecting_geometries(name)\
                 .unary_union.intersection(self.footprint)

--- a/src/xsar/utils.py
+++ b/src/xsar/utils.py
@@ -13,7 +13,7 @@ from functools import wraps, partial
 import rasterio
 import shutil
 import glob
-import gc
+import yaml
 
 logger = logging.getLogger('xsar.utils')
 logger.addHandler(logging.NullHandler())
@@ -354,7 +354,6 @@ class BlockingActorProxy():
             logger.debug('BlockingActorProxy: Reusing existing actor')
             self._actor = actor
 
-
         if self._dask_client is not None:
             logger.debug('submit new actor')
             self._actor_future = self._dask_client.submit(self._cls, *args, **kwargs, actors=True)
@@ -384,6 +383,7 @@ class BlockingActorProxy():
                 else:
                     # transparent proxy
                     return res
+
             return func
 
     def __reduce__(self):
@@ -392,3 +392,12 @@ class BlockingActorProxy():
         kwargs = self._kwargs
         kwargs['actor'] = self._actor
         return partial(BlockingActorProxy, **kwargs), (self._cls, *self._args)
+
+
+def merge_yaml(yaml_strings_list):
+    # merge a list of yaml strings in one string
+    return yaml.safe_dump(
+        yaml.safe_load(
+            '\n'.join(yaml_strings_list)
+        )
+    )

--- a/src/xsar/xml_parser.py
+++ b/src/xsar/xml_parser.py
@@ -2,9 +2,14 @@ from lxml import objectify
 import jmespath
 import logging
 from collections.abc import Iterable
+import os
+import re
+import json
+import yaml
 
 logger = logging.getLogger('xsar.xml_parser')
 logger.addHandler(logging.NullHandler())
+
 
 # TODO: no variable caching is not while  https://github.com/dask/distributed/issues/5610 is not solved
 class XmlParser:
@@ -50,10 +55,10 @@ class XmlParser:
         """
 
         xml_root = self.getroot(xml_file)
-        result = [ getattr(e, 'pyval', e) for e in xml_root.xpath(path, namespaces=self._namespaces) ]
+        result = [getattr(e, 'pyval', e) for e in xml_root.xpath(path, namespaces=self._namespaces)]
         return result
 
-    def get_var(self, xml_file, jpath):
+    def get_var(self, xml_file, jpath, describe=False):
         """
         get simple variable in xml_file.
 
@@ -63,6 +68,8 @@ class XmlParser:
             xml filename
         jpath: str
             jmespath string reaching xpath in xpath_mappings
+        describe: bool
+            If True, describe the variable (ie return xpath used)
 
         Returns
         -------
@@ -78,6 +85,9 @@ class XmlParser:
         if isinstance(xpath, tuple) and callable(xpath[0]):
             func, xpath = xpath
 
+        if describe:
+            return xpath
+
         if not isinstance(xpath, str):
             raise NotImplementedError('Non leaf xpath of type "%s" instead of str' % type(xpath).__name__)
 
@@ -87,15 +97,24 @@ class XmlParser:
 
         return result
 
-    def get_compound_var(self, xml_file, var_name):
+    def get_compound_var(self, xml_file, var_name, describe=False):
         """
 
         Parameters
         ----------
         var_name: str
+
             key in self._compounds_vars
+
         xml_file: str
+
             xml_file to use.
+
+        describe: bool
+
+            If True, only returns a string describing the variable (file, xpath, etc...)
+
+
 
         Returns
         -------
@@ -103,12 +122,18 @@ class XmlParser:
 
         """
 
+        if describe:
+            # keep only informative parts in filename
+            # sub SAFE path
+            minifile = re.sub('.*SAFE/', '', xml_file)
+            minifile = re.sub('-.*\.xml', '.xml', minifile)
+
         var_object = self._compounds_vars[var_name]
 
         func = None
-        if isinstance(var_object,dict) and 'func' in var_object and callable(var_object['func']):
+        if isinstance(var_object, dict) and 'func' in var_object and callable(var_object['func']):
             func = var_object['func']
-            if isinstance(var_object['args'],tuple):
+            if isinstance(var_object['args'], tuple):
                 args = var_object['args']
             else:
                 raise ValueError('args must be a tuple when func is called')
@@ -119,18 +144,24 @@ class XmlParser:
         if isinstance(args, dict):
             result = {}
             for key, path in args.items():
-                result[key] = self.get_var(xml_file, path)
+                result[key] = self.get_var(xml_file, path, describe=describe)
         elif isinstance(args, Iterable):
-            result = [self.get_var(xml_file, p) for p in args]
+            result = [self.get_var(xml_file, p, describe=describe) for p in args]
 
         if isinstance(args, tuple):
             result = tuple(result)
 
-        if func is not None:
+        if func is not None and not describe:
             # apply converter
             result = func(*result)
 
-        return result
+        if describe:
+            if isinstance(result, dict):
+                result = result.values()
+            description = yaml.safe_dump({var_name: {minifile: result}})
+            return description
+        else:
+            return result
 
     def __del__(self):
         logger.debug('__del__ XmlParser')

--- a/src/xsar/xsar.py
+++ b/src/xsar/xsar.py
@@ -11,9 +11,7 @@ __version__ = metadata.version('xsar')
 
 import logging
 from .utils import timing
-import numpy as np
 import os
-import numbers
 import yaml
 from importlib_resources import files
 from pathlib import Path
@@ -90,63 +88,8 @@ def open_dataset(*args, **kwargs):
     else:
         raise TypeError("Unknown dataset type from %s" % str(dataset_id))
 
-    return apply_cf_convention(sar_obj.dataset)
+    return sar_obj.dataset
 
-
-@timing
-def apply_cf_convention(dataset):
-    """
-    Apply `CF-1.7 convention <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html>`_ to a dataset
-
-    Parameters
-    ----------
-    dataset
-
-    Returns
-    -------
-    dataset wtih the cf convention
-    """
-
-    def to_cf(attr):
-        if not isinstance(attr, (str, numbers.Number, np.ndarray, np.number, list, tuple)):
-            return str(attr)
-        else:
-            return attr
-
-    attr_dict = {
-        'atrack': {
-            'units': '1'
-        },
-        'xtrack': {
-            'units': '1'
-        },
-        'longitude': {
-            'standard_name': 'longitude',
-            'units': 'degrees_east'
-        },
-        'latitude': {
-            'standard_name': 'latitude',
-            'units': 'degrees_north'
-        },
-        'sigma0_raw': {
-            'units': 'm2/m2'
-        },
-        'gamma0_raw': {
-            'units': 'm2/m2'
-        },
-    }
-
-    for k, v in dataset.attrs.items():
-        dataset.attrs[k] = to_cf(dataset.attrs[k])
-
-    dataset.attrs['Conventions'] = 'CF-1.7'
-
-    for key, attribute in attr_dict.items():
-        for key_attr, value in attribute.items():
-            if key in dataset:
-                dataset[key].attrs[key_attr] = value
-
-    return dataset
 
 def product_info(path, columns='minimal', include_multi=False, _xml_parser=None):
     """


### PR DESCRIPTION
As requested by @lanougue, this PR adds an 'history' attribute to almost all variables, in a yaml style string:

for example, for the 'incidence' variable:
```
incidence:
  annotation/s1b.xml:
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/line
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/pixel
  - /product/geolocationGrid/geolocationGridPointList/geolocationGridPoint/incidenceAngle
```