### PR TITLE
add s1meta.bursts as DA without geopandas at this stage

### DIFF
--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -832,7 +832,7 @@ class Sentinel1Meta:
         return heading
 
     @property
-    def bursts(self):
+    def _bursts(self):
         if self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.number_of_bursts') > 0:
             return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
         else:

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -837,7 +837,7 @@ class Sentinel1Meta:
             return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
         else:
             # no burst, return empty dataframe with 'burst' column
-            return pd.DataFrame({'burst': []})
+            return xr.Dataset()
 
     @property
     def approx_transform(self):

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -5,7 +5,7 @@ import warnings
 import copy
 import numpy as np
 import xarray as xr
-import pandas as pd
+import pandas as pd/
 import geopandas as gpd
 import rasterio
 from scipy.interpolate import RectBivariateSpline
@@ -836,7 +836,7 @@ class Sentinel1Meta:
         if self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.number_of_bursts') > 0:
             return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
         else:
-            # no burst, return empty dataframe with 'burst' column
+            # no burst, return empty dataset
             return xr.Dataset()
 
     @property

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -824,6 +824,14 @@ class Sentinel1Meta:
         return heading
 
     @property
+    def bursts(self):
+        if self.xml_parser.get_var(self.files['annotation'].iloc[0], 'annotation.number_of_bursts') > 0:
+            return self.xml_parser.get_compound_var(self.files['annotation'].iloc[0], 'bursts')
+        else:
+            # no burst, return empty dataframe with 'burst' column
+            return pd.DataFrame({'burst': []})
+
+    @property
     def approx_transform(self):
         """
         Affine transfom from gcps.

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -445,7 +445,6 @@ def bursts(lines_per_burst, samples_per_burst, burst_azimuthTime, burst_azimuthA
                                                'description': 'start atrack index, start xtrack index, stop atrack index, stop xtrack index'}),
         }
     )
-    da.attrs = {'lines_per_burst':lines_per_burst}
     return da
 
 

--- a/src/xsar/sentinel1_xml_mappings.py
+++ b/src/xsar/sentinel1_xml_mappings.py
@@ -25,6 +25,7 @@ namespaces = {
 
 # xpath convertion function: they take only one args (list returned by xpath)
 scalar = lambda x: x[0]
+scalar_int = lambda x: int(x[0])
 scalar_float = lambda x: float(x[0])
 date_converter = lambda x: datetime.strptime(x[0], '%Y-%m-%dT%H:%M:%S.%f')
 datetime64_array = lambda x: np.array([np.datetime64(date_converter([sx])) for sx in x])
@@ -140,6 +141,19 @@ xpath_mappings = {
         'orbit_vel_x': (float_array, '//product/generalAnnotation/orbitList/orbit/velocity/x'),
         'orbit_vel_y': (float_array, '//product/generalAnnotation/orbitList/orbit/velocity/y'),
         'orbit_vel_z': (float_array, '//product/generalAnnotation/orbitList/orbit/velocity/z'),
+        'number_of_bursts': (scalar_int, '/product/swathTiming/burstList/@count'),
+        'lines_per_burst': (scalar, '/product/swathTiming/linesPerBurst'),
+        'samples_per_burst': (scalar, '/product/swathTiming/samplesPerBurst'),
+        'azimuth_time_interval': (scalar_float, '/product/imageAnnotation/imageInformation/azimuthTimeInterval'),
+        'all_bursts': (np.array, '//product/swathTiming/burstList/burst'),
+        'burst_azimuthTime': (datetime64_array, '//product/swathTiming/burstList/burst/azimuthTime'),
+        'burst_azimuthAnxTime': (float_array, '//product/swathTiming/burstList/burst/azimuthAnxTime'),
+        'burst_sensingTime': (datetime64_array, '//product/swathTiming/burstList/burst/sensingTime'),
+        'burst_byteOffset': (np.array, '//product/swathTiming/burstList/burst/byteOffset'),
+        'burst_firstValidSample': (
+            float_2Darray_from_string_list, '//product/swathTiming/burstList/burst/firstValidSample'),
+        'burst_lastValidSample': (
+            float_2Darray_from_string_list, '//product/swathTiming/burstList/burst/lastValidSample'),
     }
 }
 
@@ -378,6 +392,45 @@ def orbit(time, frame, pos_x, pos_y, pos_z, vel_x, vel_y, vel_z,orbit_pass,platf
     return gdf
 
 
+def bursts(lines_per_burst, samples_per_burst, burst_azimuthTime, burst_azimuthAnxTime, burst_sensingTime,
+           burst_byteOffset, burst_firstValidSample, burst_lastValidSample):
+    """return burst as an xarray dataset"""
+
+    if (lines_per_burst == 0) and (samples_per_burst == 0):
+        return None
+
+    # convert to float, so we can use NaN as missing value, instead of -1
+    burst_firstValidSample = burst_firstValidSample.astype(float)
+    burst_lastValidSample = burst_lastValidSample.astype(float)
+    burst_firstValidSample[burst_firstValidSample == -1] = np.nan
+    burst_lastValidSample[burst_lastValidSample == -1] = np.nan
+    nbursts = len(burst_azimuthTime)
+    valid_locations = np.empty((nbursts, 4), dtype='int32')
+    for ibur in range(nbursts):
+        fvs = burst_firstValidSample[ibur, :]
+        lvs = burst_lastValidSample[ibur, :]
+        #valind = np.where((fvs != -1) | (lvs != -1))[0]
+        valind = np.where(np.isfinite(fvs) | np.isfinite(lvs))[0]
+        valloc = [ibur * lines_per_burst + valind.min(), fvs[valind].min(),
+                  ibur * lines_per_burst + valind.max(), lvs[valind].max()]
+        valid_locations[ibur, :] = valloc
+    da = xr.Dataset(
+        {
+            'azimuthTime': ('burst', burst_azimuthTime),
+            'azimuthAnxTime': ('burst', burst_azimuthAnxTime),
+            'sensingTime': ('burst', burst_sensingTime),
+            'byteOffset': ('burst', burst_byteOffset),
+            'firstValidSample': (['burst', 'xtrack'], burst_firstValidSample),
+            'lastValidSample': (['burst', 'xtrack'], burst_lastValidSample),
+            'valid_location': xr.DataArray(dims=['burst', 'limits'], data=valid_locations,
+                                           attrs={
+                                               'description': 'start atrack index, start xtrack index, stop atrack index, stop xtrack index'}),
+        }
+    )
+    da.attrs = {'lines_per_burst':lines_per_burst}
+    return da
+
+
 # dict of compounds variables.
 # compounds variables are variables composed of several variables.
 # the key is the variable name, and the value is a python structure,
@@ -428,6 +481,12 @@ compounds_vars = {
     'elevation': {
         'func': annotation_angle,
         'args': ('annotation.atrack', 'annotation.xtrack', 'annotation.elevation')
+    },
+    'bursts': {
+        'func': bursts,
+        'args': ('annotation.lines_per_burst', 'annotation. samples_per_burst', 'annotation. burst_azimuthTime',
+                 'annotation. burst_azimuthAnxTime', 'annotation. burst_sensingTime', 'annotation.burst_byteOffset',
+                 'annotation. burst_firstValidSample', 'annotation.burst_lastValidSample')
     },
     'orbit': {
         'func': orbit,


### PR DESCRIPTION
address issue #54 
objective: add `s1meta.bursts` 

- [x] add mappings of annotations
- [x] add compound var
- [x] validation

This PR doesn't contain the method in `s1meta` allowing to get polygons defined in atrack/xtrack because it requires that PR #46 (s1meta.geoloc) to be available.