### PR TITLE
enable bursts() method for multidataset

### DIFF
--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -4,8 +4,6 @@ import warnings
 import numpy as np
 from scipy.interpolate import RectBivariateSpline
 import xarray as xr
-import pandas as pd
-import geopandas as gpd
 import dask
 import rasterio
 import rasterio.features
@@ -20,7 +18,6 @@ from affine import Affine
 from .sentinel1_meta import Sentinel1Meta
 from .ipython_backends import repr_mimebundle
 import yaml
-import os
 
 logger = logging.getLogger('xsar.sentinel1_dataset')
 logger.addHandler(logging.NullHandler())

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -1071,14 +1071,11 @@ class Sentinel1Meta:
             subswath_labels = [uu.split(':')[2] for uu in self.subdatasets]
             for ss,subswath in enumerate(self.subdatasets):
                 metasub = Sentinel1Meta(subswath)
-                new_block = metasub.bursts()
-                new_index = new_block.index
-                new_index = zip(np.tile(subswath_labels[ss],(len(new_block))),new_index)
-                new_index = pd.MultiIndex.from_tuples(new_index, names=["subswath","burst"])
-                new_block.index = new_index
-                blocks_list.append(new_block)
+                block = metasub.bursts(only_valid_location=only_valid_location)
+                block['subswath'] = metasub.dsid
+                block = block.set_index('subswath', append=True).reorder_levels(['subswath', 'burst'])
+                blocks_list.append(block)
             blocks = pd.concat(blocks_list)
-            blocks.index.name = 'burst'
         else:
             burst_list = self._bursts
             if burst_list['burst'].size == 0:

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -1068,8 +1068,7 @@ class Sentinel1Meta:
         """
         if self.multidataset:
             blocks_list = []
-            subswath_labels = [uu.split(':')[2] for uu in self.subdatasets]
-            for ss,subswath in enumerate(self.subdatasets):
+            for subswath in self.subdatasets:
                 metasub = Sentinel1Meta(subswath)
                 block = metasub.bursts(only_valid_location=only_valid_location)
                 block['subswath'] = metasub.dsid


### PR DESCRIPTION
This PR is meant to be able to easily get the polygons of the bursts from TOPS SLC products for the different subswath when opening the multidataset wih `Sentinel1Meta` class. 
![image](https://user-images.githubusercontent.com/14925067/162446183-a7061484-39f2-4a93-9fdb-9ea9dc13693e.png)


The `geoDataFrame` returned by the `s1meta.bursts()` method in case of mutltidataset is also a multiindex:
![image](https://user-images.githubusercontent.com/14925067/162446713-6afa79d6-ab26-4e70-a8c4-96e70ee64946.png)
