### PR TITLE
s1meta.subdatasets is now a GeodataFrame

### DIFF
--- a/docs/examples/xsar.ipynb
+++ b/docs/examples/xsar.ipynb
@@ -66,9 +66,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/xsar_multiple.ipynb
+++ b/docs/examples/xsar_multiple.ipynb
@@ -101,7 +101,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "wv_slc_ds1 = xsar.open_dataset(wv_slc_meta.subdatasets[0])\n",
+    "wv_slc_ds1 = xsar.open_dataset(wv_slc_meta.subdatasets.index[0])\n",
     "wv_slc_ds1"
    ]
   },
@@ -120,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wv_slc_meta1 = xsar.Sentinel1Meta(wv_slc_meta.subdatasets[0])\n",
+    "wv_slc_meta1 = xsar.Sentinel1Meta(wv_slc_meta.subdatasets.index[0])\n",
     "wv_slc_meta1"
    ]
   },
@@ -211,12 +211,33 @@
    "source": [
     "gdf_info.iloc[0]['meta']"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37fb7130-1309-4817-929f-63df283daf7a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/src/xsar/xsar.py
+++ b/src/xsar/xsar.py
@@ -155,7 +155,7 @@ def product_info(path, columns='minimal', include_multi=False, _xml_parser=None)
         elif not s1meta.multidataset:
             df_list.append(_meta2df(s1meta))
         if s1meta.multidataset:
-            for n in s1meta.subdatasets:
+            for n in s1meta.subdatasets.index:
                 s1meta = Sentinel1Meta(n)
                 df_list.append(_meta2df(s1meta))
     df = pd.concat(df_list).reset_index(drop=True)


### PR DESCRIPTION
This is an API change.

before, `s1meta.subdatasets` was a list, it's now a GeoDataFrame. For old behaviour, users should use `list(s1meta.subdatasets.index)`

for TOPS _IW_SLC products, the main `manifest.safe` doesn't include individual footprints. So a recursive call to `Sentinel1Meta` is done to extract them.

close #80 