### PR TITLE
add possibility to skip variables at loading rasterization hR

### DIFF
--- a/docs/examples/xsar_tops_slc.ipynb
+++ b/docs/examples/xsar_tops_slc.ipynb
@@ -225,6 +225,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f639184d-92d8-485d-af11-6b697f5bd8fb",
+   "metadata": {},
+   "source": [
+    "# alternatively compute the value of a geolocation field (longitude, latitude, incidence,..) at given image coordinates\n",
+    "this method has been added to avoid adding hig resolution grids for some variable while we only need specific points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cc9e861-013c-4c91-8af5-1d05e54b7566",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s1ds.get_ll_from_SLC_geoloc(line=5,sample=3000,varname='incidence')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "99f4389d-9b72-41e7-a3af-d54d4bfce294",
    "metadata": {},
    "source": [

--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -267,13 +267,13 @@ class Sentinel1Dataset:
     def add_high_resolution_variables(self, luts=False, patch_variable=True, skip_variables=None, load_luts=True,
                                       lazy_loading=True):
         """
-        :parameter
-        luts: bool, optional
+        Parameters
+        ----------
 
+        luts: bool, optional
             if `True` return also luts as variables (ie `sigma0_lut`, `gamma0_lut`, etc...). False by default.
 
         patch_variable: bool, optional
-
             activate or not variable pathching ( currently noise lut correction for IPF2.9X)
 
         skip_variables: list, optional
@@ -422,7 +422,10 @@ class Sentinel1Dataset:
     def apply_calibration_and_denoising(self):
         """
         apply calibration and denoising functions to get high resolution sigma0 , beta0 and gamma0 + variables *_raw
-        :return:
+
+        Returns:
+        --------
+
         """
         for var_name, lut_name in self._map_var_lut.items():
             if lut_name in self._luts:
@@ -1142,7 +1145,9 @@ class Sentinel1Dataset:
     def coords2ll_SLC(self, *args):
         """
             for SLC product with irregular projected pixel spacing in range Affine transformation are not relevant
-        :return:
+
+        Returns
+        -------
         """
         lines, samples = args
         if isinstance(lines, list) or isinstance(lines, np.ndarray):
@@ -1160,7 +1165,15 @@ class Sentinel1Dataset:
         """
         1) loop on burst polygons to get rasterized landmask
         2) merge the landmask pieces into a single Dataset to replace existing 'land_mask' is any
-        :return:
+
+        Parameters
+        ----------
+
+        lazy_loading bool
+
+        Returns
+        -------
+
         """
         # TODO: add a prior step to compute the intersection between the self.dataset (could be a subset) and the different bursts
         # if 'land_mask' in self.dataset:
@@ -1740,7 +1753,10 @@ class Sentinel1Dataset:
     def get_burst_valid_location(self):
         """
         add a field 'valid_location' in the bursts sub-group of the datatree
-        :return:
+
+        Returns:
+        --------
+
         """
         nbursts = len(self.datatree['bursts'].ds['burst'])
         burst_firstValidSample = self.datatree['bursts'].ds['firstValidSample'].values

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -178,7 +178,7 @@ class Sentinel1Meta:
             'minimal': ['ipf', 'platform', 'swath', 'product', 'pols']
         }
         info_keys['all'] = info_keys['minimal'] + ['name', 'start_date', 'stop_date', 'footprint', 'coverage',
-                                                   'pixel_line_m', 'pixel_sample_m', 'orbit_pass', 'platform_heading']
+                                                   'orbit_pass', 'platform_heading'] #  'pixel_line_m', 'pixel_sample_m',
 
         if isinstance(keys, str):
             keys = info_keys[keys]
@@ -541,12 +541,12 @@ class Sentinel1Meta:
     @property
     def start_date(self):
         """start date, as datetime.datetime"""
-        return self.time_range.left
+        return '%s'%self.time_range.left
 
     @property
     def stop_date(self):
         """stort date, as datetime.datetime"""
-        return self.time_range.right
+        return '%s'%self.time_range.right
 
     @property
     def denoised(self):


### PR DESCRIPTION
Improve the way the rasterized variables are loaded for SLC products.
And fix  #127 

- [x]  add capability to get geolocation fields at specific image coordinates without loading full HR variable
- [x] add `lazy_loading` option to turn "on" of "off" the `map_block_coords()` mechanism that currently suffer memory leak
- [x] add `load_luts` option  to turn "on" of "off" the decoding and rasterization of LUTs.
- [x] prevent the usage of `resolution` when reading a IW or EW SLC product (this feature is out of scope for `xsar`)