### PR TITLE
fix missing `sampleSpacing` and `lineSpacing`

### DIFF
--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -250,6 +250,7 @@ class Sentinel1Dataset:
         # return
 
         self._dataset.attrs.update(self.s1meta.to_dict("all"))
+        self.datatree['measurement'] = self.datatree['measurement'].assign(self._dataset)
         self.datatree.attrs.update(self.s1meta.to_dict("all"))
         if 'GRD' in str(self.datatree.attrs['product']):  # load land_mask by default for GRD products
             self.add_high_resolution_variables(patch_variable=patch_variable, luts=luts, lazy_loading=lazyloading)


### PR DESCRIPTION
fix the fact that the 2 float values `sampleSpacing` and `lineSpacing` are still available in the dataset even if not HR variable is loaded.