### PR TITLE
Fix anti meridian cases

### DIFF
--- a/src/xsar/base_dataset.py
+++ b/src/xsar/base_dataset.py
@@ -729,8 +729,8 @@ class BaseDataset(ABC):
         if not raster_ds.rio.crs.is_geographic:
             raster_ds = raster_ds.rio.reproject(4326)
 
-        if self.sar_meta.cross_antemeridian and self.anti_meridian_correction_performed is False:
-            raise NotImplementedError('Antimeridian crossing not yet checked')
+        if self.sar_meta.cross_antemeridian: # for method map_raster() we do not have implemented yet the workaround for antimeridian acquisitions
+            raise NotImplementedError('Antimeridian crossing positions not yet mitigated')
 
         # get lon/lat box for xsar dataset
         lon1, lat1, lon2, lat2 = self.sar_meta.footprint.exterior.bounds
@@ -814,8 +814,8 @@ class BaseDataset(ABC):
         else:
             logger.warning('Raster variable are experimental')
 
-        if self.sar_meta.cross_antemeridian and self.anti_meridian_correction_performed is False:
-            raise NotImplementedError('Antimeridian crossing not yet checked')
+        if self.sar_meta.cross_antemeridian: # for _load_rasters_vars() there is no workaround yet for acqiisitions over antimeridian
+            raise NotImplementedError('Antimeridian crossing positions not yet mitigated')
 
         # will contain xr.DataArray to merge
         da_var_list = []

--- a/src/xsar/base_dataset.py
+++ b/src/xsar/base_dataset.py
@@ -1,3 +1,4 @@
+import pdb
 import warnings
 from abc import ABC
 from datetime import datetime
@@ -47,6 +48,7 @@ class BaseDataset(ABC):
     name = None
     sliced = False
     sar_meta = None
+    anti_meridian_correction_performed = False
     _rasterized_masks = None
     resolution = None
     _da_tmpl = None
@@ -727,7 +729,7 @@ class BaseDataset(ABC):
         if not raster_ds.rio.crs.is_geographic:
             raster_ds = raster_ds.rio.reproject(4326)
 
-        if self.sar_meta.cross_antemeridian:
+        if self.sar_meta.cross_antemeridian and self.anti_meridian_correction_performed is False:
             raise NotImplementedError('Antimeridian crossing not yet checked')
 
         # get lon/lat box for xsar dataset
@@ -812,7 +814,7 @@ class BaseDataset(ABC):
         else:
             logger.warning('Raster variable are experimental')
 
-        if self.sar_meta.cross_antemeridian:
+        if self.sar_meta.cross_antemeridian and self.anti_meridian_correction_performed is False:
             raise NotImplementedError('Antimeridian crossing not yet checked')
 
         # will contain xr.DataArray to merge

--- a/src/xsar/rcm_dataset.py
+++ b/src/xsar/rcm_dataset.py
@@ -536,6 +536,7 @@ class RcmDataset(BaseDataset):
                 if varname == 'longitude':
                     if self.sar_meta.cross_antemeridian:
                         da_var.data = da_var.data.map_blocks(to_lon180)
+                        self.anti_meridian_correction_performed = True
 
                 da_var.name = varname
 

--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -832,6 +832,7 @@ class Sentinel1Dataset(BaseDataset):
             if varname == 'longitude':
                 if self.sar_meta.cross_antemeridian:
                     da_var.data = da_var.data.map_blocks(to_lon180)
+                    self.anti_meridian_correction_performed = True
 
             da_var.name = varname
 


### PR DESCRIPTION
address #172 
after testing a solution that would go beyond the raise Error in case of antimeridian, it appears that rastering methods (`map_raster` and `_load_rasters_vars`) can simply not handle such geolocations (at least without heavy modification of the function).
Trying the rastering methods leads to artifacts:
![image](https://github.com/umr-lops/xsar/assets/14925067/e339b619-7f70-4733-a644-57f637834469)
So it is decided that the comments will be clearer in the code and in the `Exception()` msg.