### PR TITLE
fix: Only include *.tif files in Tiff file paths for RCM

### DIFF
--- a/src/xsar/rcm_dataset.py
+++ b/src/xsar/rcm_dataset.py
@@ -616,7 +616,7 @@ class RcmDataset(BaseDataset):
                 List of Tiff file paths located in a folder
             """
 
-            return glob.glob(os.path.join(self.sar_meta.path, "imagery", "*"))
+            return glob.glob(os.path.join(self.sar_meta.path, "imagery", "*.tif"))
 
         def _sort_list_files_and_get_pols(list_tiff):
             """


### PR DESCRIPTION
This minor pull request changes the RCM load digital number glob pattern from `imagery/*` to `imagery/*.tif`. This aligns with the xradarsat2 library ( https://github.com/umr-lops/xradarsat2/blob/main/src/xradarsat2/radarSat2_tiff_reader.py#L24 ). Colleagues open the .tif RCM images in ArcMap, which creates .xml metadata files in the `imagery` directory. These .xml files resulted in errors like:
```
CPLE_OpenFailedError: '/content/drive/MyDrive/20230306/RCM2_OK2203930_PK2468015_1_SC50MB_20230306_094918_HH_HV_GRD/RCM2_OK2203930_PK2468015_1_SC50MB_20230306_094918_HH_HV_GRD/imagery/2468015_1_HH.tif.aux.xml' not recognized as a supported file format.
```