### PR TITLE
Patch to get correct line coordinates in the range noise dataset for SLC products

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,18 @@
 
 Synthetic Aperture Radar (SAR) Level-1 GRD python mapper for efficient xarray/dask based processing
 
- 
+This python library allow to apply different operation on SAR images such as:
+ - calibration
+ - de-noising
+ - re-sampling
+
+The library is working regardless it is a **Sentinel-1**, a **RadarSAT-2** or a **RCM** product.
+
+The library is providing variables such as `longitude` , `latitude`, `incidence_angle` or `sigma0` at native product resolution or coarser resolution.
+
+The library perform resampling that are suitable for GRD (i.e. ground projected) SAR images. The same method is used for WV SLC, and one can consider the approximation still valid because the WV image is only 20 km X 20 km.
+
+But for TOPS (IW or EW) SLC products we recommend to use [xsarslc](https://github.com/umr-lops/xsar_slc.git)
 
 # Install
 
@@ -12,7 +23,7 @@ Synthetic Aperture Radar (SAR) Level-1 GRD python mapper for efficient xarray/da
 1) Install `xsar` (without the readers)
 
 For a faster installation and less conflicts between packages, it is better
-to make the installation with `mamba`
+to make the installation with `micromamba`
 
 ```bash
 conda install -c conda-forge mamba
@@ -21,14 +32,14 @@ conda install -c conda-forge mamba
 2) install `xsar` (without the readers)
 
 ```bash
-mamba install -c conda-forge xsar
+micromamba install -c conda-forge xsar
 ```
 3) Add optional dependencies
 
 - Add use of Radarsat-2 :
 
 ```bash
-mamba install -c conda-forge xradarsat2
+micromamba install -c conda-forge xradarsat2
 ```
 
 - Add use of RCM (RadarSat Constellation Mission)
@@ -40,7 +51,7 @@ pip install xarray-safe-rcm
 - Add use of Sentinel-1
 
 ```bash
-mamba install -c conda-forge xarray-safe-s1
+micromamba install -c conda-forge xarray-safe-s1
 ```
 
 ## Pypi
@@ -125,4 +136,3 @@ Attributes: (12/14)
 # More information
 
 For more install options and to use xsar, see [documentation](https://cyclobs.ifremer.fr/static/sarwing_datarmor/xsar/)
-

--- a/docs/examples/projections.ipynb
+++ b/docs/examples/projections.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "sigma0_image = gv.Image(sigma0_proj.sel(pol='VV')).opts(alpha=0.3, cmap='gray', clim=(0,0.05))\n",
     "#(gv.tile_sources.Wikipedia * gv.feature.land.options(scale='50m') * sigma0_image).opts(width=600,height=600)\n",
-    "(gv.tile_sources.Wikipedia * sigma0_image * gv.feature.coastline.options(scale='10m')).opts(width=600,height=600)"
+    "(gv.tile_sources.EsriImagery * sigma0_image * gv.feature.coastline.options(scale='10m')).opts(width=600,height=600)"
    ]
   },
   {
@@ -195,7 +195,7 @@
     "tmp = rioxarray.open_rasterio('/tmp/sigma0_nocolor.tiff')\n",
     "tmp = tmp.rename('sigma0_nocolor')\n",
     "tmp2 = gv.util.from_xarray(tmp)\n",
-    "gv.tile_sources.Wikipedia * gv.Image(tmp2,vdims='sigma0_nocolor',kdims=['x','y']).opts(alpha=0.7, cmap='gray', clim=(0,0.05),colorbar=True,width=500,height=200)"
+    "gv.tile_sources.EsriImagery * gv.Image(tmp2,kdims=['x','y']).opts(alpha=0.7, cmap='gray', clim=(0,0.05),colorbar=True,width=500,height=200) # vdims='sigma0_nocolor'"
    ]
   },
   {
@@ -265,11 +265,12 @@
     "# there is a transparency bug in geoviews (https://github.com/holoviz/geoviews/issues/571)\n",
     "# but if loading this tiff in google earth, it should render properly\n",
     "tmp = rioxarray.open_rasterio('/tmp/sigma0_color.tiff')\n",
-    "tmp = tmp.rename('sigma0_color').isel(band=0)\n",
-    "tmp2 = gv.util.from_xarray(tmp)\n",
-    "print(tmp2)\n",
+    "tmp = tmp.rename('sigma0_color').isel(band=1)\n",
+    "print(tmp)\n",
+    "# tmp2 = gv.util.from_xarray(tmp,vdims='sigma0_color')\n",
+    "# print('empt2\\n====================',tmp2)\n",
     "# (gv.tile_sources.Wikipedia * gv.load_tiff('/tmp/sigma0_color.tiff')).opts(width=600,height=600)\n",
-    "(gv.tile_sources.Wikipedia * gv.Image(tmp2,vdims='sigma0_color',kdims=['x','y']).opts(cmap='magma',colorbar=True)).opts(width=600,height=600)"
+    "(gv.tile_sources.EsriImagery * gv.Image(tmp,vdims='sigma0_color',kdims=['x','y']).opts(cmap='magma',colorbar=True,tools=['hover'])).opts(width=600,height=600) # "
    ]
   },
   {
@@ -390,7 +391,7 @@
    "source": [
     "merged_lonlat = merged_grid.rio.reproject(4326)\n",
     "(\n",
-    "    gv.tile_sources.Wikipedia * gv.Image(merged_lonlat['spd']).opts(cmap='jet', alpha=0.3) \n",
+    "    gv.tile_sources.EsriImagery * gv.Image(merged_lonlat['spd']).opts(cmap='jet', alpha=0.3) \n",
     "    * gv.Image(merged_lonlat['sigma0']).opts(cmap='gray', clim=(0,0.05), alpha=0.7)\n",
     ").opts(width=600,height=600)\n",
     "                                                           "

--- a/docs/examples/projections.ipynb
+++ b/docs/examples/projections.ipynb
@@ -170,7 +170,9 @@
    },
    "outputs": [],
    "source": [
-    "sigma0_proj.sel(pol='VV').rio.to_raster('/tmp/sigma0_nocolor.tiff')"
+    "s0vvproj = sigma0_proj.sel(pol='VV')\n",
+    "s0vvproj.attrs['name'] = 'sigma0 VV projected using rioxarray'\n",
+    "s0vvproj.rio.to_raster('/tmp/sigma0_nocolor.tiff')"
    ]
   },
   {
@@ -250,7 +252,9 @@
     "rgb_sigma0.name = 'sigma0_rgba'\n",
     "xsar_obj.datatree['measurement'] = xsar_obj.datatree['measurement'].assign(xr.merge([xsar_obj.dataset,rgb_sigma0]))\n",
     "xsar_obj.recompute_attrs()\n",
-    "xsar_obj.dataset['sigma0_rgba'].rio.reproject('epsg:4326',shape=(1000,1000),nodata=0).rio.to_raster('/tmp/sigma0_color.tiff')"
+    "s0rgba = xsar_obj.dataset['sigma0_rgba'].rio.reproject('epsg:4326',shape=(1000,1000),nodata=0)\n",
+    "s0rgba.attrs['name'] = 'sigma0 RGBA projected using rioxarray'\n",
+    "s0rgba.rio.to_raster('/tmp/sigma0_color.tiff')"
    ]
   },
   {

--- a/docs/examples/xsar_tops_slc.ipynb
+++ b/docs/examples/xsar_tops_slc.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# s1ds.add_high_resolution_variables() # deprecated method for SLC -> see https://github.com/umr-lops/xsar_slc \n",
+    "s1ds.add_high_resolution_variables()\n",
     "s1ds.dataset"
    ]
   },
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# s1ds.apply_calibration_and_denoising() # deprecated method for SLC -> see https://github.com/umr-lops/xsar_slc \n",
+    "s1ds.apply_calibration_and_denoising() \n",
     "s1ds.dataset"
    ]
   },
@@ -272,7 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# s1ds.dataset['ground_heading']"
+    "s1ds.dataset['ground_heading']"
    ]
   },
   {
@@ -349,8 +349,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# rgs = s1ds.dataset['range_ground_spacing']\n",
-    "# rgs"
+    "rgs = s1ds.dataset['range_ground_spacing']\n",
+    "rgs"
    ]
   },
   {
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# hv.Curve(rgs).opts(width=400,show_grid=True)\n"
+    "hv.Curve(rgs).opts(width=400,show_grid=True)\n"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.15"
   },
   "toc-autonumbering": true
  },

--- a/docs/examples/xsar_tops_slc.ipynb
+++ b/docs/examples/xsar_tops_slc.ipynb
@@ -83,7 +83,7 @@
     "#gv.tile_sources.Wikipedia*gv.Polygons(multids.bursts(only_valid_location=True)['geometry']).opts(width=800,height=450,alpha=0.5)\n",
     "import pandas as pd\n",
     "tmp = pd.concat([xsar.Sentinel1Dataset(onesubswath).get_bursts_polygons(only_valid_location=True) for onesubswath in multids.subdatasets.index])\n",
-    "gv.tile_sources.Wikipedia*gv.Polygons(tmp['geometry']).opts(width=800,height=450,alpha=0.5)\n"
+    "gv.tile_sources.EsriImagery*gv.Polygons(tmp['geometry']).opts(width=800,height=450,alpha=0.5)\n"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "outputs": [],
    "source": [
     "tmp2 = pd.concat([xsar.Sentinel1Dataset(onesubswath).get_bursts_polygons(only_valid_location=False) for onesubswath in multids.subdatasets.index])\n",
-    "gv.tile_sources.Wikipedia*gv.Polygons(tmp2['geometry']).opts(width=800,height=450,alpha=0.2)*gv.Polygons(tmp['geometry']).opts(width=800,height=450,alpha=0.2)\n"
+    "gv.tile_sources.EsriImagery*gv.Polygons(tmp2['geometry']).opts(width=800,height=450,alpha=0.2)*gv.Polygons(tmp['geometry']).opts(width=800,height=450,alpha=0.2)\n"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.15"
   },
   "toc-autonumbering": true
  },

--- a/docs/examples/xsar_tops_slc.ipynb
+++ b/docs/examples/xsar_tops_slc.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1ds.add_high_resolution_variables()\n",
+    "# s1ds.add_high_resolution_variables() # deprecated method for SLC -> see https://github.com/umr-lops/xsar_slc \n",
     "s1ds.dataset"
    ]
   },
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1ds.apply_calibration_and_denoising()\n",
+    "# s1ds.apply_calibration_and_denoising() # deprecated method for SLC -> see https://github.com/umr-lops/xsar_slc \n",
     "s1ds.dataset"
    ]
   },
@@ -272,7 +272,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1ds.dataset['ground_heading']"
+    "# s1ds.dataset['ground_heading']"
    ]
   },
   {
@@ -349,8 +349,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rgs = s1ds.dataset['range_ground_spacing']\n",
-    "rgs"
+    "# rgs = s1ds.dataset['range_ground_spacing']\n",
+    "# rgs"
    ]
   },
   {
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Curve(rgs).opts(width=400,show_grid=True)\n"
+    "# hv.Curve(rgs).opts(width=400,show_grid=True)\n"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.10.8"
   },
   "toc-autonumbering": true
  },

--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -284,9 +284,10 @@ class Sentinel1Dataset(BaseDataset):
         self.datatree.attrs.update(self.sar_meta.to_dict("all"))
 
         # load land_mask by default for GRD products
+
+        self.add_high_resolution_variables(
+            patch_variable=patch_variable, luts=luts, lazy_loading=lazyloading)
         if 'GRD' in str(self.datatree.attrs['product']):
-            self.add_high_resolution_variables(
-                patch_variable=patch_variable, luts=luts, lazy_loading=lazyloading)
             if self.apply_recalibration:
                 self.select_gains()
             self.apply_calibration_and_denoising()
@@ -500,12 +501,12 @@ class Sentinel1Dataset(BaseDataset):
             self._dataset = self._dataset.merge(
                 self._load_from_geoloc(geoloc_vars, lazy_loading=lazy_loading))
 
-            
-            self.add_swath_number()   
-                
-            if self.apply_recalibration:
-                self.add_gains(config["auxiliary_names"][self.sar_meta.short_name.split(":")[-2][0:3]][self.aux_config_name]["AUX_CAL"],
-                               config["auxiliary_names"][self.sar_meta.short_name.split(":")[-2][0:3]][self.aux_config_name]["AUX_PP1"])
+            if 'GRD' in str(self.datatree.attrs['product']):
+                self.add_swath_number()
+
+                if self.apply_recalibration:
+                    self.add_gains(config["auxiliary_names"][self.sar_meta.short_name.split(":")[-2][0:3]][self.aux_config_name]["AUX_CAL"],
+                                   config["auxiliary_names"][self.sar_meta.short_name.split(":")[-2][0:3]][self.aux_config_name]["AUX_PP1"])
 
             rasters = self._load_rasters_vars()
             if rasters is not None:

--- a/src/xsar/sentinel1_meta.py
+++ b/src/xsar/sentinel1_meta.py
@@ -41,7 +41,10 @@ class Sentinel1Meta(BaseMeta):
 
     @timing
     def __init__(self, name):
-        from safe_s1.metadata import Sentinel1Reader
+        try:
+            from safe_s1.metadata import Sentinel1Reader
+        except:
+            from safe_s1.reader import Sentinel1Reader
         self.reader = Sentinel1Reader(name)
 
         if not name.startswith('SENTINEL1_DS:'):


### PR DESCRIPTION
issue in the data IW SLC documented here:
https://jira-projects.cls.fr/browse/MPCS-3581 and https://github.com/umr-lops/xsar_slc/issues/175
to replace https://github.com/umr-lops/xarray-safe-s1/pull/20
An example of product which needs correction:
`safe = '/home/datawork-cersat-public/cache/project/mpc-sentinel1/data/esa/sentinel-1a/L1/IW/S1A_IW_SLC__1S/2021/026/S1A_IW_SLC__1SDV_20210126T154330_20210126T154357_036311_0442A0_0003.SAFE' #subswath 1 -> shift 1503 lines`

- [x] check IW SLC
- [x] check EW SLC -> found an issue, `line_jump_meas=14` while `line_jump_noise=15` -> we exclude EW from this patch for now.
- [x] check IW GRD (not concerned by the correction)
- [x] check IW SL2 (currently azimuth time used to correct is not OK -> cannot check it properly)
- [x] check WV SLC (not concerned by the correction)
- [x] check EW GRD (not concerned by the correction)
- [x] compile sphinx doc
- [x] test over 300 slice IW SLC (900 subswath)