### PR TITLE
restore default behavior for SLC product: only show Digital Numbers in `dt[measurement]`

### DIFF
--- a/src/xsar/sentinel1_dataset.py
+++ b/src/xsar/sentinel1_dataset.py
@@ -292,9 +292,10 @@ class Sentinel1Dataset(BaseDataset):
 
         # load land_mask by default for GRD products
 
-        self.add_high_resolution_variables(
-            patch_variable=patch_variable, luts=luts, lazy_loading=lazyloading)
+
         if 'GRD' in str(self.datatree.attrs['product']):
+            self.add_high_resolution_variables(
+                                   patch_variable=patch_variable, luts=luts, lazy_loading=lazyloading)
             if self.apply_recalibration:
                 self.select_gains()
             self.apply_calibration_and_denoising()


### PR DESCRIPTION
address issue #209 
- [x] make html
- [x] high level tests
- [x] unit tests

# content of measurement

```python
dt['measurement']
DataTree('measurement', parent="None")
    Dimensions:         (line: 13545, sample: 25072, pol: 2)
    Coordinates:
      * line            (line) int64 108kB 0 1 2 3 4 ... 13541 13542 13543 13544
      * sample          (sample) int64 201kB 0 1 2 3 4 ... 25068 25069 25070 25071
      * pol             (pol) object 16B 'VV' 'VH'
    Data variables:
        digital_number  (pol, line, sample) complex64 5GB dask.array<chunksize=(1, 5000, 5000), meta=np.ndarray>
        time            (line) datetime64[ns] 108kB 2020-11-14T18:56:53.472650 .....
        sampleSpacing   float64 8B 2.33
        lineSpacing     float64 8B 13.96
    Attributes: (12/15)
        name:              SENTINEL1_DS:/home/datawork-cersat-public/project/mpc-...
        short_name:        SENTINEL1_DS:S1B_IW_SLC__1SDV_20201114T185653_20201114...
        product:           SLC
        safe:              S1B_IW_SLC__1SDV_20201114T185653_20201114T185720_02426...
        swath:             IW
        multidataset:      False
        ...                ...
        start_date:        2020-11-14 18:56:53.472650
        stop_date:         2020-11-14 18:57:18.620326
        footprint:         POLYGON ((-13.86419610441108 28.35736004678626, -12.93...
        coverage:          171km * 92km (line * sample )
        orbit_pass:        Ascending
        platform_heading:  -12.61623021245103
```

## RAM footprint

```python
get_memory_usage()
'RAM usage: 11.0 Go'
```