### PR TITLE
Fix ERA5 raster reader time selection

### DIFF
--- a/src/xsar/raster_readers.py
+++ b/src/xsar/raster_readers.py
@@ -193,7 +193,7 @@ def era5_0250_1h(fname, **kwargs):
 
     ds_era5 = xr.open_dataset(fname, chunks={'time': 1})
     ds_era5 = ds_era5[['u10', 'v10', 'latitude025', 'longitude025']]
-    ds_era5 = ds_era5.sel(time=str(kwargs['date']))
+    ds_era5 = ds_era5.sel(time=str(kwargs['date']), method="nearest")
     ds_era5 = ds_era5.drop('time')
 
     ds_era5 = ds_era5.rename(


### PR DESCRIPTION
Adding method="nearest" in era5 reader to fix #222 

Currently only tested on one file.