### PR TITLE
fix python version conflict at build stage

### DIFF
--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ipython
+  - python
   - pre-commit
   - pytest
   - pytest-reportlog

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,6 @@ dependencies:
   - xarray
   - rioxarray >=0.10
   - pandoc
-  - python >=3.8
+  - python
   - importlib_resources
   - lxml


### PR DESCRIPTION
try to fix the error in the xsar-condafeedstock build related to conflict version of python
see https://github.com/conda-forge/xsar-feedstock/pull/38 